### PR TITLE
Add Rostral.io — Semantic Monitoring Tool for PUBLIC DATA Workflows

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -2362,5 +2362,17 @@
     ],
     "attributes": [],
     "date_added": "2025-05-13"
-  }
+  },
+  {
+  "slug": "rostral-io",
+  "title": "Rostral.io",
+  "url": "https://rostral.io",
+  "tooltip": "Rostral.io is a self-hosted semantic monitoring platform for public documents. It enables deep inspection of PDF/HTML sources using YAML-based configuration and integrates with local LLMs for high-precision insight extraction. Suitable for tracking grants, legal updates, and regulatory reports.",
+  "categories": [
+    "PUBLIC DATA"
+  ],
+  "attributes": [],
+  "date_added": "2025-08-06"
+}
+
 ]


### PR DESCRIPTION
This PR adds Rostral.io to the PUBLIC DATA category of osint-resources.

Rostral.io is a self-hosted platform for semantic monitoring of public documents, with support for YAML templates, PDF/HTML parsing pipelines, and local LLM integration for advanced insight extraction. It’s well-suited for tracking grants, legal updates, and regulatory changes.

The tool aligns with the repo's focus on OSINT-enabling platforms and complements other entries focused on document intelligence and automation.

Let me know if you'd like any edits to improve compatibility or categorization
